### PR TITLE
Fix single err check statement in extract package

### DIFF
--- a/internal/extract/extract.go
+++ b/internal/extract/extract.go
@@ -19,7 +19,7 @@ func ProjectConfig(dir string) (*project.Config, error) {
 	config.Name = pkg.ImportPath
 
 	deps, err := extractDependencies(config.Name, dir)
-	if err != err {
+	if err != nil {
 		return config, err
 	}
 


### PR DESCRIPTION
Minor edit to fix an error checking statement, detected using https://github.com/dominikh/go-staticcheck.